### PR TITLE
feat: allow EffectName to rename AE2 parts

### DIFF
--- a/src/main/java/gripe/_90/arseng/mixin/EffectNameMixin.java
+++ b/src/main/java/gripe/_90/arseng/mixin/EffectNameMixin.java
@@ -1,0 +1,48 @@
+package gripe._90.arseng.mixin;
+
+import appeng.api.ids.AEComponents;
+import appeng.api.parts.IPart;
+import appeng.blockentity.AEBaseBlockEntity;
+import appeng.blockentity.networking.CableBusBlockEntity;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Cancellable;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.BlockHitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.hollingsworth.arsnouveau.common.spell.effect.EffectName;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+import appeng.util.SettingsFrom;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EffectName.class)
+public class EffectNameMixin {
+    @WrapOperation(method = "onResolveBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getBlockEntity(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/entity/BlockEntity;"))
+    private BlockEntity onResolveBlock(Level instance, BlockPos pos, Operation<BlockEntity> original, @Cancellable CallbackInfo ci, @Local Component name, @Local(argsOnly = true) LivingEntity shooter, @Local(argsOnly = true) BlockHitResult bhr) {
+        BlockEntity be = original.call(instance, pos);
+        Player player = shooter instanceof Player playerEntity ? playerEntity : null;
+        DataComponentMap map = DataComponentMap.builder().set(AEComponents.EXPORTED_CUSTOM_NAME, name).build();
+
+        if (be instanceof CableBusBlockEntity cableBusBlock) {
+            IPart part = cableBusBlock.getPart(bhr.getDirection().getOpposite());
+            if (part != null) {
+                part.importSettings(SettingsFrom.MEMORY_CARD, map, player);
+            }
+            ci.cancel();
+        } else if (be instanceof AEBaseBlockEntity baseBlockEntity) {
+            baseBlockEntity.importSettings(SettingsFrom.MEMORY_CARD, map, player);
+            ci.cancel();
+        }
+        return be;
+    }
+}

--- a/src/main/java/gripe/_90/arseng/mixin/EffectNameMixin.java
+++ b/src/main/java/gripe/_90/arseng/mixin/EffectNameMixin.java
@@ -1,48 +1,65 @@
 package gripe._90.arseng.mixin;
 
-import appeng.api.ids.AEComponents;
-import appeng.api.parts.IPart;
-import appeng.blockentity.AEBaseBlockEntity;
-import appeng.blockentity.networking.CableBusBlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.hollingsworth.arsnouveau.common.spell.effect.EffectName;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Cancellable;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.phys.BlockHitResult;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-
-import com.hollingsworth.arsnouveau.common.spell.effect.EffectName;
 import com.llamalad7.mixinextras.sugar.Local;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.phys.BlockHitResult;
 
+import appeng.api.ids.AEComponents;
+import appeng.blockentity.AEBaseBlockEntity;
+import appeng.blockentity.networking.CableBusBlockEntity;
 import appeng.util.SettingsFrom;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(EffectName.class)
 public class EffectNameMixin {
-    @WrapOperation(method = "onResolveBlock", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getBlockEntity(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/entity/BlockEntity;"))
-    private BlockEntity onResolveBlock(Level instance, BlockPos pos, Operation<BlockEntity> original, @Cancellable CallbackInfo ci, @Local Component name, @Local(argsOnly = true) LivingEntity shooter, @Local(argsOnly = true) BlockHitResult bhr) {
-        BlockEntity be = original.call(instance, pos);
-        Player player = shooter instanceof Player playerEntity ? playerEntity : null;
-        DataComponentMap map = DataComponentMap.builder().set(AEComponents.EXPORTED_CUSTOM_NAME, name).build();
+    // spotless:off
+    @WrapOperation(
+            method = "onResolveBlock",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/Level;getBlockEntity(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/entity/BlockEntity;"))
+    // spotless:on
+    private BlockEntity onResolveBlock(
+            Level instance,
+            BlockPos pos,
+            Operation<BlockEntity> original,
+            @Cancellable CallbackInfo ci,
+            @Local Component name,
+            @Local(argsOnly = true) LivingEntity shooter,
+            @Local(argsOnly = true) BlockHitResult result) {
+        var be = original.call(instance, pos);
+        var player = shooter instanceof Player playerEntity ? playerEntity : null;
+        var components = DataComponentMap.builder()
+                .set(AEComponents.EXPORTED_CUSTOM_NAME, name)
+                .build();
 
-        if (be instanceof CableBusBlockEntity cableBusBlock) {
-            IPart part = cableBusBlock.getPart(bhr.getDirection().getOpposite());
+        if (be instanceof CableBusBlockEntity cableBus) {
+            var part = cableBus.getPart(result.getDirection().getOpposite());
+
             if (part != null) {
-                part.importSettings(SettingsFrom.MEMORY_CARD, map, player);
+                part.importSettings(SettingsFrom.MEMORY_CARD, components, player);
             }
+
             ci.cancel();
-        } else if (be instanceof AEBaseBlockEntity baseBlockEntity) {
-            baseBlockEntity.importSettings(SettingsFrom.MEMORY_CARD, map, player);
+        } else if (be instanceof AEBaseBlockEntity aeBE) {
+            aeBE.importSettings(SettingsFrom.MEMORY_CARD, components, player);
             ci.cancel();
         }
+
         return be;
     }
 }

--- a/src/main/resources/arseng.mixins.json
+++ b/src/main/resources/arseng.mixins.json
@@ -4,6 +4,7 @@
   "package": "gripe._90.arseng.mixin",
   "mixins": [
     "ConfigInventoryMixin",
+    "EffectNameMixin",
     "ScribesTileMixin",
     "WixieCauldronTileMixin"
   ],


### PR DESCRIPTION
Adds the ability for the name glyph to rename AE2 parts so that the custom names appear in the pattern access terminal