### PR TITLE
Only add AE2's budding blocks to ars_nouveau golem tags

### DIFF
--- a/src/data/java/gripe/_90/arseng/data/TagsProvider.java
+++ b/src/data/java/gripe/_90/arseng/data/TagsProvider.java
@@ -17,6 +17,7 @@ import net.minecraft.world.level.block.Block;
 import net.neoforged.neoforge.common.data.BlockTagsProvider;
 
 import appeng.api.features.P2PTunnelAttunement;
+import appeng.core.definitions.AEBlocks;
 import appeng.datagen.providers.tags.ConventionTags;
 
 import gripe._90.arseng.ArsEnergistique;
@@ -69,8 +70,13 @@ abstract class TagsProvider {
             ArsEngBlocks.getBlocks()
                     .forEach(block -> tag(BlockTags.MINEABLE_WITH_PICKAXE).add(block.block()));
 
-            tag(BlockTagProvider.BUDDING_BLOCKS).addOptionalTag(ConventionTags.BUDDING_BLOCKS_BLOCKS.location());
-            tag(BlockTagProvider.CLUSTER_BLOCKS).addOptionalTag(ConventionTags.CLUSTERS_BLOCKS.location());
+            tag(BlockTagProvider.BUDDING_BLOCKS)
+                    .add(
+                            AEBlocks.FLAWLESS_BUDDING_QUARTZ.block(),
+                            AEBlocks.FLAWED_BUDDING_QUARTZ.block(),
+                            AEBlocks.CHIPPED_BUDDING_QUARTZ.block(),
+                            AEBlocks.DAMAGED_BUDDING_QUARTZ.block());
+            tag(BlockTagProvider.CLUSTER_BLOCKS).add(AEBlocks.QUARTZ_CLUSTER.block());
         }
     }
 }

--- a/src/generated/resources/.cache/cd741ffb41cb89ce4531bd887afd21916db76112
+++ b/src/generated/resources/.cache/cd741ffb41cb89ce4531bd887afd21916db76112
@@ -1,4 +1,4 @@
-// 1.21.1	2024-12-09T11:56:55.750876069	vanilla/Tags for minecraft:block mod id arseng
-61bb38bcfa6ac543e0380915e55692bb183e1be3 data/ars_nouveau/tags/block/golem/budding.json
-c5a033d890f5a75b85002e83c39474334c51aded data/ars_nouveau/tags/block/golem/cluster.json
+// 1.21.1	2026-02-20T15:13:37.813920668	vanilla/Tags for minecraft:block mod id arseng
+ca4546b25b9a0c110132844b297d362990f16813 data/ars_nouveau/tags/block/golem/budding.json
+944cb1404f1e9ff48b0e39369ca1d07ffdbc052f data/ars_nouveau/tags/block/golem/cluster.json
 4f5425cef36aa4ff2514a30f8d19972e44094181 data/minecraft/tags/block/mineable/pickaxe.json

--- a/src/generated/resources/data/ars_nouveau/tags/block/golem/budding.json
+++ b/src/generated/resources/data/ars_nouveau/tags/block/golem/budding.json
@@ -1,8 +1,8 @@
 {
   "values": [
-    {
-      "id": "#c:budding_blocks",
-      "required": false
-    }
+    "ae2:flawless_budding_quartz",
+    "ae2:flawed_budding_quartz",
+    "ae2:chipped_budding_quartz",
+    "ae2:damaged_budding_quartz"
   ]
 }

--- a/src/generated/resources/data/ars_nouveau/tags/block/golem/cluster.json
+++ b/src/generated/resources/data/ars_nouveau/tags/block/golem/cluster.json
@@ -1,8 +1,5 @@
 {
   "values": [
-    {
-      "id": "#c:clusters",
-      "required": false
-    }
+    "ae2:quartz_cluster"
   ]
 }


### PR DESCRIPTION
Previously this would break functionality from GeOre in combination with Ars Nouveau.

This would add all budding blocks (not only those from AE2) to the Ars Nouveau tag, which in turn allows Amethyst Golems to harvest GeOre Budding Blocks when they're not supposed to.